### PR TITLE
Don't unset cloexec on server end of wayland sockets

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -21,16 +21,8 @@ pub fn get_client_sock(
     display: &mut wayland_server::Display,
 ) -> (Client, (UnixStream, UnixStream)) {
     let (display_sock, client_sock) = UnixStream::pair().unwrap();
-    let raw_fd = display_sock.as_raw_fd();
-    let fd_flags =
-        fcntl::FdFlag::from_bits(fcntl::fcntl(raw_fd, fcntl::FcntlArg::F_GETFD).unwrap()).unwrap();
-    fcntl::fcntl(
-        raw_fd,
-        fcntl::FcntlArg::F_SETFD(fd_flags.difference(fcntl::FdFlag::FD_CLOEXEC)),
-    )
-    .unwrap();
     (
-        unsafe { display.create_client(raw_fd, &mut ()) },
+        unsafe { display.create_client(display_sock.as_raw_fd(), &mut ()) },
         (display_sock, client_sock),
     )
 }


### PR DESCRIPTION
This can prevent cosmic-panel applets closing. Presumably they didn't receive an EOF from the socket since other applets got a copy of the server-end fd.

As far as I can tell there's no reason to do this, for the server end of the socket. It seems to work find with this code removed.

Fixes https://github.com/pop-os/cosmic-panel/issues/2.