### PR TITLE
Fix key press/release handling, passing `raw_code` rather than `keysym`

### DIFF
--- a/src/client/handlers/keyboard.rs
+++ b/src/client/handlers/keyboard.rs
@@ -118,7 +118,7 @@ impl<W: WrapperSpace> KeyboardHandler for GlobalState<W> {
 
         let _ = kbd.input::<(), _>(
             self,
-            event.keysym,
+            event.raw_code,
             KeyState::Pressed,
             SERIAL_COUNTER.next_serial(),
             event.time,
@@ -150,7 +150,7 @@ impl<W: WrapperSpace> KeyboardHandler for GlobalState<W> {
 
         match kbd.input::<(), _>(
             self,
-            event.keysym,
+            event.raw_code,
             KeyState::Released,
             SERIAL_COUNTER.next_serial(),
             event.time,


### PR DESCRIPTION
Wayland sends keycodes to clients, and relies on the client to handle the mapping to keysyms based on the keymap and modifier state.

With this, a `GtkEntry` in a cosmic-panel applet is working, at least mostly.

This seems to be the cause of the issue I mentioned in https://github.com/pop-os/xdg-shell-wrapper/issues/8#issuecomment-1247393835.