### PR TITLE
WIP update keymap based on keymap from server

### DIFF
--- a/src/client/handlers/keyboard.rs
+++ b/src/client/handlers/keyboard.rs
@@ -9,6 +9,7 @@ use sctk::{
     seat::keyboard::{keysyms::XKB_KEY_Escape, KeyboardHandler, RepeatInfo},
 };
 use smithay::{backend::input::KeyState, input::keyboard::FilterResult, utils::SERIAL_COUNTER};
+use xkbcommon::xkb;
 
 impl<W: WrapperSpace> KeyboardHandler for GlobalState<W> {
     fn enter(
@@ -215,6 +216,25 @@ impl<W: WrapperSpace> KeyboardHandler for GlobalState<W> {
         _modifiers: sctk::seat::keyboard::Modifiers,
     ) {
         // TODO should these be handled specially
+    }
+
+    fn update_keymap(
+        &mut self,
+        _conn: &sctk::reexports::client::Connection,
+        _qh: &sctk::reexports::client::QueueHandle<Self>,
+        keyboard: &sctk::reexports::client::protocol::wl_keyboard::WlKeyboard,
+        keymap: xkb::Keymap,
+    ) {
+        if let Some(seat) =
+            self.server_state
+                .seats
+                .iter_mut()
+                .find(|SeatPair { client, .. }| {
+                    client.kbd.as_ref().map(|k| k == keyboard).unwrap_or(false)
+                })
+        {
+            seat.server.add_keyboard_from_keymap(keymap, 200, 20);
+        }
     }
 }
 


### PR DESCRIPTION
Fix for https://github.com/pop-os/xdg-shell-wrapper/issues/8, though due to https://github.com/pop-os/xdg-shell-wrapper/issues/10, changes to the selected layout group aren't forwarded from the server.

Requires https://github.com/Smithay/client-toolkit/pull/299 and https://github.com/Smithay/smithay/pull/750.

I believe this results in unregistering the `wl_keyboard` and creating a new one. Having a way in smithay to alter the existing `wl_keyboard` may work better.

The above PRs also have soundness issues due to the non-thread-safe ref-counting in xdgcommon, and how smithay/sctk assume they hold the only references.